### PR TITLE
#205 - Widget layer indicates mouse actions to its sprites

### DIFF
--- a/app/assets/javascripts/builder/widgets/hotspot_widget.js.coffee
+++ b/app/assets/javascripts/builder/widgets/hotspot_widget.js.coffee
@@ -35,13 +35,6 @@ class App.Builder.Widgets.HotspotWidget extends App.Builder.Widgets.Widget
     @model.on 'change:radius', @updateContentSize, @
     @model.on 'change:position', @updatePosition, @
 
-    # RFCTR @dira 2013-02-03 these events should be mouse-over #190
-    @on 'mouseover', @onMouseOver, @
-    @on 'mouseout',  @onMouseOut,  @
-    @on 'mousedown', @onMouseDown, @
-    @on 'mouseup',   @onMouseUp,   @
-    @on 'mousemove', @onMouseMove, @
-
 
   draw: (ctx) ->
     r = @model.get('radius')
@@ -92,26 +85,27 @@ class App.Builder.Widgets.HotspotWidget extends App.Builder.Widgets.Widget
     )
 
 
-  onMouseOver: ->
+  mouseOver: ->
+    super
     @setOpacity(@MOUSEOVER_OPACITY)
 
 
-  onMouseOut:  ->
-    @setOpacity(@DEFAULT_OPACITY)
-    @setCursor @CURSOR_DEFAULT unless @resizing
+  mouseOut:  ->
+    super
+    unless @resizing
+      @setOpacity(@DEFAULT_OPACITY)
+      @setCursor @CURSOR_DEFAULT
 
 
-  onMouseDown: (e) ->
-    point = e.canvasPoint
+  mouseDown: (options) ->
+    point = options.canvasPoint
     inControl = @_isPointInsideControl(point)
 
-    @draggable = not inControl
-
-    @_startResize(e) if inControl
+    @_startResize(options) if inControl
 
 
-  onMouseUp: (e) ->
-    @_endResize(e) if @resizing
+  mouseUp: (options) ->
+    @_endResize(options) if @resizing
 
 
   doubleClick: ->
@@ -119,8 +113,12 @@ class App.Builder.Widgets.HotspotWidget extends App.Builder.Widgets.Widget
     # App.vent.trigger('widget:touch:edit', this)
 
 
-  onMouseMove: (e) ->
-    point = e.canvasPoint
+  draggedTo: ->
+    super unless @resizing
+
+
+  mouseMove: (options) ->
+    point = options.canvasPoint
 
     inControl = @resizing or @_isPointInsideControl(point)
     @setCursor(if inControl then @CURSOR_RESIZE else @CURSOR_MOVE)

--- a/app/assets/javascripts/builder/widgets/sprite_widget.js.coffee
+++ b/app/assets/javascripts/builder/widgets/sprite_widget.js.coffee
@@ -22,10 +22,8 @@ class App.Builder.Widgets.SpriteWidget extends App.Builder.Widgets.Widget
     # @model - is set by the super constructor
     @sprite = new App.Builder.Widgets.Lib.Sprite(options)
 
-    @on 'change:orientation', @updateOrientation
-    @on 'deselect body:click',@deselect
-    @on 'double_click',       @doubleClick
-    @on 'mousemove',          @mouseMove
+    @on 'change:orientation',  @updateOrientation
+    @on 'deselect body:click', @deselect
 
     App.vent.on 'canvas:click_outside', @deselect
 
@@ -65,11 +63,9 @@ class App.Builder.Widgets.SpriteWidget extends App.Builder.Widgets.Widget
     @_setCursor('move')
 
 
-  doubleClick: (event) ->
-    @_setActiveSpriteFromClick(event)
-
-
   applyOrientation: (orientation) ->
+    @currentOrientation = orientation
+
     position = orientation.get('position')
 
     @setPosition(new cc.Point(position.x, position.y))
@@ -87,11 +83,7 @@ class App.Builder.Widgets.SpriteWidget extends App.Builder.Widgets.Widget
     orientationWidget.update()
 
 
-  select: (widget = null) =>
-    _widget = widget || this
-
-    App.vent.trigger 'sprite_widget:select', _widget
-
+  select: ->
     @showBorder()
 
 
@@ -99,12 +91,10 @@ class App.Builder.Widgets.SpriteWidget extends App.Builder.Widgets.Widget
     @hideBorder()
 
 
-  # RFCTR - Move to widget layer
-  mouseOver: (e) ->
+  mouseOver: ->
     @_setCursor('move')
 
 
-  # RFCTR - Move to widget layer
   mouseOut: ->
     @_setCursor('default')
 
@@ -169,12 +159,3 @@ class App.Builder.Widgets.SpriteWidget extends App.Builder.Widgets.Widget
   _setCursor: (cursor) ->
     document.body.style.cursor = cursor
 
-
-  # RFCTR!!!!
-  _setActiveSpriteFromClick: (event) ->
-    activeSpriteWidget = App.builder.widgetLayer.widgetAtPoint(event._point)
-    return unless activeSpriteWidget
-
-    # RFCTR  Needs ventilation
-    App.builder.widgetLayer.setSelectedWidget(activeSpriteWidget)
-    @select(activeSpriteWidget)

--- a/app/assets/javascripts/builder/widgets/widget.js.coffee
+++ b/app/assets/javascripts/builder/widgets/widget.js.coffee
@@ -8,14 +8,8 @@
 # _opacity
 # _highlighted
 # _mouse_over
-# draggable
 #
 class App.Builder.Widgets.Widget extends cc.Node
-
-  draggable: true
-
-  _mouse_over: false
-
 
   constructor: (options) ->
     super
@@ -23,15 +17,11 @@ class App.Builder.Widgets.Widget extends cc.Node
     @model = options.model
     _.extend(this, Backbone.Events)
 
-    @setOpacity(255)
     # @_highlighted = false
+    @_mouse_over = false
 
     @updatePosition()
-
-    @on 'mouseover', @mouseOver
-    @on 'mouseout',  @mouseOut
-    @on 'mousemove', @mouseMove
-    # @on 'dblclick',  @doubleClick
+    @setOpacity(255)
 
     # App.vent.on 'widget:change_zorder', @changeZOrder
 
@@ -48,10 +38,6 @@ class App.Builder.Widgets.Widget extends cc.Node
     position = @model.get('position')
     @setPosition new cc.Point(position.x, position.y)
 
-  # changeZOrder: (z) ->
-    # @setZOrder(z)
-    # @trigger 'change', 'zOrder'
-
 
   mouseOver: ->
     @_mouse_over = true
@@ -60,33 +46,33 @@ class App.Builder.Widgets.Widget extends cc.Node
   mouseOut: ->
     @_mouse_over = false
 
+
+  # options: { touch, canvasPoint }
+  mouseDown: (options) ->
+
+
+  mouseUp: ->
+
+
+  mouseMove: ->
+
+
   doubleClick: ->
-    # noop
 
 
-  # isHighlighted: ->
-    # return @_highlighted
+  select: ->
 
 
-  # highlight: ->
-    # return if @isHighlighted()
-    # @_highlighted = true
-    # App.Builder.Widgets.WidgetDispatcher.trigger('widget:highlight', @id)
+  deselect: ->
 
 
-  # unHighlight: ->
-    # return unless @isHighlighted()
-    # @_highlighted = false
-    # App.Builder.Widgets.WidgetDispatcher.trigger('widget:unhighlight', @id)
+  draggedTo: (position) ->
+    widget = @model
+    if widget instanceof App.Models.SpriteWidget
+      widget = @currentOrientation
+    widget.set position: {x: position.x, y: position.y}
 
-
-
-  # setZOrder: (z, triggerEvent=true) ->
-    # @_zOrder = z
-
-
-  # getZOrder: ->
-    # @_zOrder
+    @setPosition(position, false)
 
 
   rect: ->
@@ -133,4 +119,33 @@ class App.Builder.Widgets.Widget extends cc.Node
 
   # isTouchWidget: ->
     # @ instanceof App.Builder.Widgets.TouchWidget
+
+  # isHighlighted: ->
+    # return @_highlighted
+
+
+  # highlight: ->
+    # return if @isHighlighted()
+    # @_highlighted = true
+    # App.Builder.Widgets.WidgetDispatcher.trigger('widget:highlight', @id)
+
+
+  # unHighlight: ->
+    # return unless @isHighlighted()
+    # @_highlighted = false
+    # App.Builder.Widgets.WidgetDispatcher.trigger('widget:unhighlight', @id)
+
+
+
+  # setZOrder: (z, triggerEvent=true) ->
+    # @_zOrder = z
+
+
+  # getZOrder: ->
+    # @_zOrder
+
+
+  # changeZOrder: (z) ->
+    # @setZOrder(z)
+    # @trigger 'change', 'zOrder'
 

--- a/app/assets/javascripts/builder/widgets/widget_layer.js.coffee
+++ b/app/assets/javascripts/builder/widgets/widget_layer.js.coffee
@@ -1,10 +1,6 @@
 # Displays the widgets on the main canvas, and handles user interaction (mouse
 # and touch events).
-#
-# Methods:
-#   _calculateTouchFrom(event) - Calculates the touch point relative to the canvas
-#
-
+# @_capturedWidget the widget on which mouse down was triggered (before other UI events)
 class App.Builder.Widgets.WidgetLayer extends cc.Layer
 
   DEFAULT_CURSOR = 'default'
@@ -32,15 +28,6 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
     @widgets.on 'remove', @removeWidget, @
     @widgets.on 'change:position change:scale', @updateWidget, @
 
-    App.vent.on 'sprite_widget:select', @deselectSpriteWidgets
-
-
-  addCanvasMouseLeaveListener: ->
-    # RFCTR - Move to Widget layer,
-    #         #builder-canvas will belong to it. (@el)
-    $('#builder-canvas').bind 'mouseout', (event) ->
-      document.body.style.cursor = 'default'
-
 
   addWidget: (widget) ->
     return if widget instanceof App.Models.SpriteOrientation
@@ -65,10 +52,8 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
 
 
   widgetAtPoint: (point) ->
-    #
-    # RFCTR - Move to model layer
-    # widgetWithHighestZ =  @widgetHighestZAtPoint(point)
-    # return widgetWithHighestZ if widgetWithHighestZ
+    #widgetWithHighestZ =  @widgetHighestZAtPoint(point)
+    #return widgetWithHighestZ if widgetWithHighestZ
 
     for widget,i in @views
       if widget.getIsVisible() and widget.isPointInside(point)
@@ -76,9 +61,15 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
 
     null
 
+  #widgetAtPoint: (point) ->
+  #  #widgetWithHighestZ =  @widgetHighestZAtPoint(point)
+  #  #return widgetWithHighestZ if widgetWithHighestZ
+  #
+  #  return widget for widget,i in @views when widget.getIsVisible() and widget.isPointInside(point)
+  #  return null
 
   #
-  # RFCTR: Re-integrate this functionality, move to model / collection
+  # RFCTR: Re-integrate this functionality, move to modal
   #
   # widgetHighestZAtPoint: (point) ->
   #   widgetWithHighestZ =
@@ -89,30 +80,25 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
   #   widgetWithHighestZ || false
   #
 
-
   ccTouchesBegan: (touches) ->
-    widget = @widgetAtTouch(touches[0])
+    touch = touches[0]
+    point = touch.locationInView()
+    widget = @widgetAtPoint(point)
     return unless widget
 
-    point = touches[0].locationInView()
-
-    widget.trigger 'mousedown',
-      touch: touches[0]
+    widget.mouseDown
+      touch: touch
       canvasPoint: point
 
     @_capturedWidget = widget
     @_previousPoint = new cc.Point(point.x, point.y)
-
-    true
 
 
   ccTouchesMoved: (touches) ->
     touch = touches[0]
     point = touch.locationInView()
 
-    if @_capturedWidget and @_capturedWidget.draggable
-      @moveCapturedWidget(point)
-
+    @moveCapturedWidget(point) if @_capturedWidget?
     @mouseOverWidgetAtTouch(touch, @_capturedWidget)
 
 
@@ -121,8 +107,8 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
     point = touch.locationInView()
 
     if @_capturedWidget
-      @_capturedWidget.trigger 'mouseup',
-        touch: touch,
+      @_capturedWidget.mouseUp
+        touch: touch
         canvasPoint: point
 
     delete @_previousPoint
@@ -130,18 +116,14 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
 
 
   moveCapturedWidget: (point) ->
-    @_previousPoint ||= point
+    newPoint = new cc.Point(parseInt(point.x), parseInt(point.y))
+    @_previousPoint ||= newPoint
 
     delta = cc.ccpSub(point, @_previousPoint)
-    newPos = cc.ccpAdd(delta, @_capturedWidget.getPosition())
+    newPosition = cc.ccpAdd(delta, @_capturedWidget.getPosition())
 
-    widget = @_capturedWidget.model
-    if widget instanceof App.Models.SpriteWidget
-      widget = widget.getOrientationFor(@widgets.currentKeyframe)
-    widget.set position: {x: newPos.x, y: newPos.y}
-
-    @_capturedWidget.setPosition(newPos, false)
-    @_previousPoint = new cc.Point(parseInt(point.x), parseInt(point.y))
+    @_capturedWidget.draggedTo(newPosition)
+    @_previousPoint = newPoint
 
 
   mouseOverWidgetAtTouch: (touch, widget=null) ->
@@ -149,35 +131,31 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
     widget ||= @widgetAtPoint(point)
 
     if widget
-      widget.trigger 'mousemove',
+      widget.mouseMove
         touch:       touch
         canvasPoint: point
 
     if widget isnt @_mouseOverWidget
-      if @_mouseOverWidget
-        @_mouseOverWidget.trigger 'mouseout',
-          touch:       touch
-          canvasPoint: point
-          newWidget:   widget
+      @_mouseOverWidget?.mouseOut
+        touch:       touch
+        canvasPoint: point
+        newWidget:   widget
 
-      if widget
-        widget.trigger 'mouseover',
-          touch:          touch
-          canvasPoint:    point
-          previousWidget: @_mouseOverWidget
+      widget?.mouseOver
+        touch:          touch
+        canvasPoint:    point
+        previousWidget: @_mouseOverWidget
 
       @_mouseOverWidget = widget
 
 
   setSelectedWidget: (widget) ->
     @_selectedWidget = widget
+    widget.select()
 
-  #
+  ##
   # RFCTR - Used by the sprite form palette
-  #         Not sure if we'll need to keep it though, it smells.
-  #
-  #         Consider better naming convention (i.e., hasSelectedWidget)
-  #         to better match, if used.
+  #         Not sure if we'll need to keep it though.
   #                                         C.W. 2/2/2013
   #
   #   hasCapturedWidget: ->
@@ -188,30 +166,64 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
     widget.deselect() for widget in @views when widget.isSpriteWidget()
 
 
-  addClickOutsideEventListener: =>
+  addCanvasMouseLeaveListener: ->
+    # RFCTR - Move to Widget layer,
+    #         #builder-canvas will belong to it. (@el)
+    $('#builder-canvas').bind 'mouseout', (event) ->
+      document.body.style.cursor = 'default'
+    $('#builder-canvas').bind 'mouseout', (event) ->
+      document.body.style.cursor = 'default'
+
+
+  addClickOutsideEventListener: =>   # RFCTR - unnecessary
     # # Checks for a click outside the widget
     cc.canvas.addEventListener 'click', (event) =>
-      touch = @_calculateTouchFrom(event)
+      el = cc.canvas
+      pos = {left:0, top:0, height:el.height}
+
+      ##
+      # RFCTR - DRY up
+      #       - Convert to function that returns touch object
+      #
+
+      while el != null
+        pos.left += el.offsetLeft
+        pos.top += el.offsetTop
+        el = el.offsetParent
+
+      tx = event.pageX
+      ty = event.pageY
+
+      mouseX = (tx - pos.left) / cc.Director.sharedDirector().getContentScaleFactor()
+      mouseY = (pos.height - (ty - pos.top)) / cc.Director.sharedDirector().getContentScaleFactor()
+
+      touch = new cc.Touch(0, mouseX, mouseY)
+      touch._setPrevPoint(cc.TouchDispatcher.preTouchPoint.x, cc.TouchDispatcher.preTouchPoint.y)
+      cc.TouchDispatcher.preTouchPoint.x = mouseX
+      cc.TouchDispatcher.preTouchPoint.y = mouseY
+
+      #
+      # END DRY
+      ##
 
       return unless @_selectedWidget
 
-      #
-      # RFCTR - Should invoke method rather than trigger event
-      #
       widget = @widgetAtPoint(touch.locationInView())
       if widget and @_selectedWidget isnt widget or not widget
-        @_selectedWidget.trigger 'deselect'
+        @_selectedWidget.deselect()
 
 
+  # RFCTR - Dry up duplicate code w/ above
   addDblClickEventListener: ->
+    ## FIXME Need a cleaner way to check for doubleclicks
     cc.canvas.addEventListener 'dblclick', (event) =>
       touch = @_calculateTouchFrom(event)
+      point = touch.locationInView()
 
-      #
-      # RFCTR - Should invoke method rather than trigger event
-      #
-      widget = @widgetAtPoint(touch.locationInView())
-      widget.trigger('double_click', touch, event) if widget
+      widget = @widgetAtPoint(point)
+      if widget?
+        widget.doubleClick touch: touch, point: point
+        @setSelectedWidget(widget)
 
 
   _calculateTouchFrom: (event) ->
@@ -238,4 +250,3 @@ class App.Builder.Widgets.WidgetLayer extends cc.Layer
     cc.TouchDispatcher.preTouchPoint.y = mouseY
 
     touch
-


### PR DESCRIPTION
directly, not through events
this is a lot simpler
and it also allows us to override actions
making it simpler to change behavior for some widgets
without using class 'constants' such as `draggable`
