### PR TITLE
Scene index height #438

### DIFF
--- a/app/assets/javascripts/app/views/scenes/index.js.coffee
+++ b/app/assets/javascripts/app/views/scenes/index.js.coffee
@@ -87,7 +87,9 @@ class App.Views.SceneIndex extends Backbone.View
 
 
   adjustSize: ->
-    $('#scene-list, .scene-list').css height: "#{$(window).height()}px"
+    $('#scene-list').css height: "#{$(window).height() - 128}px"
+    offset = @$el.offset()?.top || 128
+    @$el.css height: "#{$(window).height() - offset}px"
 
 
   toggleListView: (event) ->

--- a/app/assets/stylesheets/scenes.css.less
+++ b/app/assets/stylesheets/scenes.css.less
@@ -1,3 +1,8 @@
+#scene-list {
+  top: 127px;
+  position: relative;
+}
+
 .scene-list::-webkit-scrollbar {
   display: none;
 }
@@ -9,6 +14,7 @@
   overflow: -moz-scrollbars-vertical;
   background-repeat: no-repeat;
   background-position: 30px center;
+  position: relative;
 
   li {
     .round-corners();
@@ -21,7 +27,6 @@
     margin-top: 10px;
     z-index: 10 !important;
     position: relative;
-    top: 127px;
 
     span.scene-frame {
       cursor: default;
@@ -176,9 +181,7 @@
 }
 
 #list-view-toggle {
-  position: relative;
-  top: 131px;
-  left: 72px;
+  margin-left: 72px;
   font-size: 11px;
 
   span:hover {


### PR DESCRIPTION
now the scene index does not occupy the entire
height, but starts below the toolbar; the view
switcher is always visible
