### PR TITLE
Fixed multiple asset upload and deletion #469

### DIFF
--- a/app/assets/javascripts/app/templates/assets/fonts/download.jst.hamlc
+++ b/app/assets/javascripts/app/templates/assets/fonts/download.jst.hamlc
@@ -9,7 +9,7 @@
         %span.label.label-important= locale.fileupload.error
           = file.error
     - else
-      %td.preview
+      %td.preview{ "data-id" => "#{file.id}" }
         &nbsp;
       %td.name
         %a{:download => "#{file.name}", :href => "#{file.url}", :title => "#{file.name}"}
@@ -19,6 +19,6 @@
         %span= App.Lib.DateTimeHelper.timeToHuman(file.created_at)
       %td{:colspan => "6"}
       %td.delete
-        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}", "data-id" => "#{file.id}"}
+        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}"}
           %i.icon-trash.icon-white
           %span= locale.fileupload.destroy

--- a/app/assets/javascripts/app/templates/assets/images/download.jst.hamlc
+++ b/app/assets/javascripts/app/templates/assets/images/download.jst.hamlc
@@ -11,7 +11,7 @@
           = file.error
 
     - else
-      %td.preview
+      %td.preview{ "data-id" => "#{file.id}" }
         - if file.thumbnail_url
           %a{:download => "#{file.name}", :href => "#{file.url}", :rel => "gallery", :title => "#{file.name}"}
             %img{:src => "#{file.thumbnail_url}"}
@@ -23,6 +23,6 @@
         %span= App.Lib.DateTimeHelper.timeToHuman(file.created_at)
       %td{:colspan => "7"}
       %td.delete
-        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}", "data-id" => "#{file.id}"}
+        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}"}
           %i.icon-trash.icon-white
           %span= locale.fileupload.destroy

--- a/app/assets/javascripts/app/templates/assets/sounds/download.jst.hamlc
+++ b/app/assets/javascripts/app/templates/assets/sounds/download.jst.hamlc
@@ -9,7 +9,7 @@
         %span.label.label-important= locale.fileupload.error
           = file.error
     - else
-      %td.preview
+      %td.preview{ "data-id" => "#{file.id}" }
         &nbsp;
       %td.name
         %a{:download => "#{file.name}", :href => "#{file.url}", :rel => "#{file.thumbnail_url}", :title => "#{file.name}"}
@@ -19,6 +19,6 @@
         %span= App.Lib.DateTimeHelper.timeToHuman(file.created_at)
       %td{:colspan => "6"}
       %td.delete
-        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}", "data-id" => "#{file.id}"}
+        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}"}
           %i.icon-trash.icon-white
           %span= locale.fileupload.destroy

--- a/app/assets/javascripts/app/templates/assets/videos/download.jst.hamlc
+++ b/app/assets/javascripts/app/templates/assets/videos/download.jst.hamlc
@@ -9,7 +9,7 @@
         %span.label.label-important= locale.fileupload.error
           = file.error
     - else if file.transcode_complete
-      %td.preview
+      %td.preview{ "data-id" => "#{file.id}" }
         - if file.thumbnail_url
           %a.video-thumbnail{:href => '#', :rel => "gallery", :title => "#{file.name}", 'data-video' => "#{JSON.stringify(file)}"}
             %img{:src => "#{file.thumbnail_url}"}
@@ -22,7 +22,7 @@
         %span= App.Lib.DateTimeHelper.timeToHuman(file.created_at)
       %td{:colspan => "6"}
       %td.delete
-        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}", "data-id" => "#{file.id}"}
+        %button.btn.btn-danger.delete-asset{"data-type" => "#{file.delete_type}", "data-url" => "#{file.delete_url}"}
           %i.icon-trash.icon-white
           %span= locale.fileupload.destroy
     - else

--- a/app/assets/javascripts/app/views/assets/library.js.coffee
+++ b/app/assets/javascripts/app/views/assets/library.js.coffee
@@ -9,7 +9,15 @@ class App.Views.AssetLibrary extends Backbone.View
     @assetType = @options.assetType
     @assets = @options.assets
     @acceptedFileTypes = @acceptedFileTypes(@assetType)
-    @assets.on 'reset add remove', @render, @
+    @_addListeners()
+
+
+  _addListeners: ->
+    @assets.on 'reset add remove', @loadAndShowFileData, @
+
+
+  _removeListeners: ->
+    @assets.off 'reset add remove', @loadAndShowFileData, @
 
 
   render: ->
@@ -19,6 +27,14 @@ class App.Views.AssetLibrary extends Backbone.View
     @
 
 
+  # TODO invoke this when modal is hidden
+  # close: ->
+    # @$('#fileupload').fileupload 'disable'
+    # $('.content-modal').removeClass 'asset-library-modal'
+    # @_removeListeners()
+
+
+
   initAssetLib: ->
     $('.content-modal').addClass 'asset-library-modal'
     @$('#fileupload').fileupload(
@@ -26,43 +42,48 @@ class App.Views.AssetLibrary extends Backbone.View
       downloadTemplate : JST["app/templates/assets/#{@assetType}s/download"]
       uploadTemplate   : JST["app/templates/assets/#{@assetType}s/upload"]
     ).bind('fileuploaddestroyed',  (event, data) =>
-      destroy = $(data.context.context)
-      # For uploaded assets, the context is the TR row. For new ones, it is the button
-      destroy = $('.delete-asset', destroy) unless destroy.hasClass('delete-asset')
-      id = destroy.data('id')
-      @assets.remove @assets.get(id)
-    ).bind 'fileuploadcompleted', (event, data) =>
-      @assets.add data.result
+      deleteButton = $(data.context.context)
+      id = deleteButton.closest('tr').find('.preview').data('id')
+      @assets.remove @assets.get(id), from_upload: true
+    ).bind('fileuploadcompleted', (event, data) =>
+      @assets.add data.result, from_upload: true
+    )
 
 
   loadAndShowFileData: ->
+    return if arguments[2]?.from_upload
+
     files = @assets.map (asset) -> asset.attributes
 
     fileData = @$('#fileupload').data 'fileupload'
     fileData._adjustMaxNumberOfFiles(files.length)
 
-    template = fileData._renderDownload(files).prependTo @$('#fileupload .files')
+    template = fileData._renderDownload(files)
+    template.addClass 'in'
+    @$('#fileupload .files').html('').append(template)
     fileData._reflow = fileData?._transition and template.length and template[0].offsetWidth
 
-    template.addClass 'in'
-
     @$('#loading').remove()
-    @$('#searchtable').show()
 
-    @$('.table-striped').advancedtable
-      searchCaseSensitive : false
-      afterRedrawThis     : @
-      afterRedraw         : @attachDeleteEvent
-      searchField         : '#search'
-      loadElement         : '#loader'
-      descImage           : '/assets/advancedtable/down.png'
-      ascImage            : '/assets/advancedtable/up.png'
-
-
-  closeAssetLib: ->
-    @$('#fileupload').fileupload 'disable'
-    $('.content-modal').removeClass 'asset-library-modal'
-    @assets.off 'reset', @render, @
+    # 2013-04-30 @dira
+    # Advanced table removes all information from the tr - classes, data
+    # which interferes with the expectations of the jqueryupload plugin.
+    # Before re-enabling this make sure the following scenario works:
+    # * upload 2 assets; delete one of them;
+    # * refresh the page; delete the remaining asset
+    #
+    # At all times the collection should have the correct number of elements
+    # and there is no JS error.
+    #
+    # @$('#searchtable').show()
+    # @$('.table-striped').advancedtable
+      # searchCaseSensitive : false
+      # afterRedrawThis     : @
+      # afterRedraw         : @attachDeleteEvent
+      # searchField         : '#search'
+      # loadElement         : '#loader'
+      # descImage           : '/assets/advancedtable/down.png'
+      # ascImage            : '/assets/advancedtable/up.png'
 
 
   fileTypePattern: () ->


### PR DESCRIPTION
It did not work anymore after we changed the view
to add/remove to the Backbone collection (and serenader)
instead of fetching.
Adding multiple assets resulted in a sequence of
calls to `render`. Which re-initialized the upload
plugin and lost the old handlers.
- do not re-initialize the upload plugin when
  the data changes; just re-render the assets
- let the upload plugin handle all the UI; do not
  re-render when the upload plugin adds assets to the
  collection
- removed the advanced table plugin. It interferes
  with jqueryupload, messing its rendering and
  expectations
