### PR TITLE
ISSUE #517 Move system fonts out of Resources before compilation.

### DIFF
--- a/app/models/abstract_storybook_application.rb
+++ b/app/models/abstract_storybook_application.rb
@@ -12,10 +12,11 @@ class AbstractStorybookApplication
   @downloadable_file_extension_regex = nil
 
   def initialize(storybook, storybook_json, target)
-    @storybook       = storybook
-    @json            = storybook_json
-    @transient_files = []
-    @target          = target
+    @storybook         = storybook
+    @json              = storybook_json
+    @transient_files   = []
+    @unused_file_names = []
+    @target            = target
   end
 
   def logger
@@ -23,48 +24,23 @@ class AbstractStorybookApplication
   end
 
   def download_files_and_sanitize_json(hash_or_array)
-    case hash_or_array
-    when Hash
-      hash_or_array.each do |key, value|
-        if value.is_a?(Hash) || value.is_a?(Array)
-          download_files_and_sanitize_json(value)
-        else
-          file_name = download_file(value)
-          hash_or_array[key] = file_name
-        end
-      end
-    when Array
-      hash_or_array.each_with_index do |value, key|
-        if value.is_a?(Hash) || value.is_a?(Array)
-          download_files_and_sanitize_json(value)
-        else
-          file_name = download_file(value)
-          hash_or_array[key] = file_name
-        end
-      end
+    @json_hash = traverse_json_hash(hash_or_array) do |transient_hash_or_array, key, value|
+      file_name = download_file(value)
+      transient_hash_or_array[key] = file_name
+      transient_hash_or_array
     end
-    hash_or_array
   end
 
-  def download_file(file)
-    return file unless file.is_a?(String)
-    file_ext = File.extname(file)
-
-    if file_ext.match(self.class.downloadable_file_extension_regex)
-      if file.match(/^http/)
-        new_file_name = SecureRandom.hex
-        File.open(File.join(CRUCIBLE_RESOURCES_DIR, new_file_name + file_ext), 'wb+') do |asset|
-          open(file, 'rb') do |read_file|
-            asset << read_file.read
-            @transient_files << asset.path
-          end
-        end
-        return File.basename(@transient_files.last)
-      elsif file.match(/^\/assets/)
-        return File.basename(file)
-      end
+  def move_unused_files_out_of_compilation
+    traverse_json_hash(@json_hash) do |transient_hash_or_array, _, value|
+      stage_for_move(value)
+      transient_hash_or_array
     end
-    file
+    FileUtils.mv(unused_files_movement_paths, File.join(CRUCIBLE_RESOURCES_DIR, '..'))
+  end
+
+  def move_unused_files_to_resources
+    FileUtils.mv(unused_files_movement_paths('..'), CRUCIBLE_RESOURCES_DIR)
   end
 
   def cleanup
@@ -102,11 +78,77 @@ class AbstractStorybookApplication
     @downloadable_file_extension_regex
   end
 
+  # System font names that could be moved out Resource directory
+  # so that these are not packged with compiled application. It
+  # only returns only fonts for now but we could extend it to
+  # include any other files.
+  def self.system_font_names
+    Dir.glob(File.join(CRUCIBLE_RESOURCES_DIR, '*.ttf')).map { |p| File.basename(p) }
+  end
+
   private
+
+  def stage_for_move(file_name)
+    if self.class.system_font_names.include?(file_name)
+      @unused_file_names << file_name if @unused_file_names.exclude?(file_name)
+    end
+  end
+
+  def traverse_json_hash(json_hash_or_array, &block)
+    case json_hash_or_array
+    when Hash
+      json_hash_or_array.each do |key, value|
+        if value.is_a?(Hash) || value.is_a?(Array)
+          traverse_json_hash(value, &block)
+        else
+          json_hash_or_array = yield(json_hash_or_array, key, value)
+        end
+      end
+    when Array
+      json_hash_or_array.each_with_index do |value, key|
+        if value.is_a?(Hash) || value.is_a?(Array)
+          traverse_json_hash(value, &block)
+        else
+          json_hash_or_array = yield(json_hash_or_array, key, value)
+        end
+      end
+    end
+    json_hash_or_array
+  end
 
   def write_json_file
     File.open(File.join(CRUCIBLE_RESOURCES_DIR, 'structure-ipad.json'), 'w') do |f|
       f.write(ActiveSupport::JSON.encode(@json_hash))
     end
+  end
+
+  def download_file(file)
+    return file unless file.is_a?(String)
+    file_ext = File.extname(file)
+
+    if file_ext.match(self.class.downloadable_file_extension_regex)
+      if file.match(/^http/)
+        return fetch_file(file, file_ext)
+
+      elsif file.match(/^\/assets/)
+        return File.basename(file)
+      end
+    end
+    file
+  end
+
+  def fetch_file(url, ext)
+    new_file_name = SecureRandom.hex
+    File.open(File.join(CRUCIBLE_RESOURCES_DIR, new_file_name + ext), 'wb+') do |asset|
+      open(url, 'rb') do |read_file|
+        asset << read_file.read
+        @transient_files << asset.path
+      end
+    end
+    File.basename(@transient_files.last)
+  end
+
+  def unused_files_movement_paths(modifier = '')
+    @unused_file_names.map { |ufn| File.join(CRUCIBLE_RESOURCES_DIR, modifier, ufn) }
   end
 end

--- a/app/models/android_storybook_application.rb
+++ b/app/models/android_storybook_application.rb
@@ -4,11 +4,13 @@ class AndroidStorybookApplication < AbstractStorybookApplication
   CRUCIBLE_ANDROID_DIR = File.join(Rails.root, '../../Crucible/HelloWorld/android/')
 
   def compile
-    @json_hash = download_files_and_sanitize_json(ActiveSupport::JSON.decode(@json))
+    download_files_and_sanitize_json(ActiveSupport::JSON.decode(@json))
     logger.info "Going to compile application with json:\n\n"
     logger.info @json_hash.inspect
     write_json_file
+    move_unused_files_out_of_compilation
     build_application
+    move_unused_files_to_resources
     @json_hash
   end
 

--- a/app/models/ios_storybook_application.rb
+++ b/app/models/ios_storybook_application.rb
@@ -12,12 +12,17 @@ class IosStorybookApplication < AbstractStorybookApplication
   end
 
   def compile
-    @json_hash = download_files_and_sanitize_json(ActiveSupport::JSON.decode(@json))
+    download_files_and_sanitize_json(ActiveSupport::JSON.decode(@json))
     logger.info "Going to compile application with json:\n\n"
     logger.info @json_hash.inspect
     write_json_file
     write_rake_file
-    xbuild_application
+    move_unused_files_out_of_compilation
+    begin
+      xbuild_application
+    ensure
+      move_unused_files_to_resources
+    end
     @json_hash
   end
 

--- a/app/queues/android_compilation_queue.rb
+++ b/app/queues/android_compilation_queue.rb
@@ -10,10 +10,13 @@ class AndroidCompilationQueue < GenericQueue
     storybook = Storybook.find(storybook_id)
     storybook_application = AndroidStorybookApplication.new(storybook, storybook_json, 'testing')
 
-    storybook_application.compile
-    storybook_application.upload_compiled_application
-    storybook_application.cleanup
-    storybook_application.send_notification
+    begin
+      storybook_application.compile
+      storybook_application.upload_compiled_application
+      storybook_application.send_notification
+    ensure
+      storybook_application.cleanup
+    end
     storybook_application
   end
 end

--- a/app/queues/ios_compilation_queue.rb
+++ b/app/queues/ios_compilation_queue.rb
@@ -10,10 +10,13 @@ class IosCompilationQueue < GenericQueue
     storybook = Storybook.find(storybook_id)
     storybook_application = IosStorybookApplication.new(storybook, storybook_json, 'testing')
 
-    storybook_application.compile
-    storybook_application.upload_compiled_application
-    #storybook_application.cleanup
-    storybook_application.send_notification
+    begin
+      storybook_application.compile
+      storybook_application.upload_compiled_application
+      storybook_application.send_notification
+    ensure
+      storybook_application.cleanup
+    end
     storybook_application
   end
 end

--- a/spec/models/abstract_storybook_application_spec.rb
+++ b/spec/models/abstract_storybook_application_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe AbstractStorybookApplication do
+  let(:storybook) { Factory(:storybook) }
+  let(:storybook_json) {
+    '{"Configurations":{"pageFlipSound":{"forward":"page-flip-sound.mp3","backward":"page-flip-sound.mp3"},"pageFlipTransitionDuration":null,"paragraphTextFadeDuration":null,"autoplayPageTurnDelay":null,"autoplayParagraphDelay":null,"homeMenuForPages":{"normalStateImage":"home-button.png","tappedStateImage":"home-button-over.png","position":[20,20]}},"Pages":[{"API":{"CCMoveTo":[{"actionTag":2,"duration":0,"position":[516,388]},{"actionTag":3,"duration":3,"position":[522,372]}],"CCScaleTo":[{"actionTag":1,"duration":0,"intensity":1}],"CCSequence":[],"CCDelayTime":[],"CCSpawn":[],"CCStorySwipeEnded":{"runAction":[{"runAfterSwipeNumber":1,"spriteTag":2,"actionTags":[3]}]},"CCStoryTouchableNode":{"nodes":[]},"CCSprites":[{"image":"https://fakes3.amazonaws.com/images/787/page11-bg-ipad.jpg","spriteTag":2,"position":[516.255735732449,387.9793814432966],"actions":[1,2]}]},"Page":{"settings":{"number":1},"text":{"paragraphs":[{"linesOfText":[{"text":"Lorem Ipsum Lorem Ipsum Lorem Ipsum","xOffset":318,"yOffset":139,"fontType":"arial.ttf","fontColor":[255,0,0],"fontHighlightColor":[255,0,0],"fontSize":25}],"highlightingTimes":[0],"voiceAudioFile":null},{"linesOfText":[{"text":"Noot Noot Noot Noot Noot Noot Pingu Pingu","xOffset":309,"yOffset":145,"fontType":"ComicSansMS.ttf","fontColor":[255,0,0],"fontHighlightColor":[255,0,0],"fontSize":25}],"highlightingTimes":[0],"voiceAudioFile":null}]}}},{"API":{"CCMoveTo":[{"actionTag":5,"duration":0,"position":[503,378]}],"CCScaleTo":[{"actionTag":4,"duration":0,"intensity":1}],"CCSequence":[],"CCDelayTime":[],"CCSpawn":[],"CCStorySwipeEnded":{"runAction":[]},"CCStoryTouchableNode":{"nodes":[]},"CCSprites":[{"image":"https://fakes3.amazonaws.com/images/786/page9-bg-ipad.jpg","spriteTag":3,"position":[502.9365035959409,378.2268041237107],"actions":[4,5]}]},"Page":{"settings":{"number":2},"text":{"paragraphs":[{"linesOfText":[{"text":"Lorem Ipsum Lorem Ipsum Lorem Ipsum","xOffset":307,"yOffset":216,"fontType":"arial.ttf","fontColor":[255,0,0],"fontHighlightColor":[255,0,0],"fontSize":25}],"highlightingTimes":[0],"voiceAudioFile":null},{"linesOfText":[{"text":"","fontType":"Arial.ttf","fontColor":[255,183,213],"fontHighlightColor":[255,0,0],"fontSize":25}],"highlightingTimes":[0],"voiceAudioFile":null}]}}}],"MainMenu":{"CCSprites":[{"image":"https://fakes3.amazonaws.com/images/785/page10-bg-ipad.jpg","spriteTag":1,"position":[502.37069649155956,386.34020618556167],"visible":true}],"fallingPhysicsSettings":{"plistfilename":"snowflake-main-menu.plist"},"MenuItems":[{"normalStateImage":"/assets/sprites/read_it_myself.png","tappedStateImage":"/assets/sprites/read_it_myself.png","storyMode":"readItMyself","position":[814,128]},{"normalStateImage":"/assets/sprites/read_to_me.png","tappedStateImage":"/assets/sprites/read_to_me.png","storyMode":"readToMe","position":[477,126]},{"normalStateImage":"/assets/sprites/auto_play.png","tappedStateImage":"/assets/sprites/auto_play.png","storyMode":"autoPlay","position":[158,120]}],"API":{}}}'
+    }
+
+  let(:processed_json_hash) {
+        { "Configurations"=>{"pageFlipSound"=>{"forward"=>"page-flip-sound.mp3", "backward"=>"page-flip-sound.mp3"}, "pageFlipTransitionDuration"=>nil, "paragraphTextFadeDuration"=>nil, "autoplayPageTurnDelay"=>nil, "autoplayParagraphDelay"=>nil, "homeMenuForPages"=>{"normalStateImage"=>"home-button.png", "tappedStateImage"=>"home-button-over.png", "position"=>[20, 20]}}, "Pages"=>[{"API"=>{"CCMoveTo"=>[{"actionTag"=>2, "duration"=>0, "position"=>[516, 388]}, {"actionTag"=>3, "duration"=>3, "position"=>[522, 372]}], "CCScaleTo"=>[{"actionTag"=>1, "duration"=>0, "intensity"=>1}], "CCSequence"=>[], "CCDelayTime"=>[], "CCSpawn"=>[], "CCStorySwipeEnded"=>{"runAction"=>[{"runAfterSwipeNumber"=>1, "spriteTag"=>2, "actionTags"=>[3]}]}, "CCStoryTouchableNode"=>{"nodes"=>[]}, "CCSprites"=>[{"image"=>"random.jpg", "spriteTag"=>2, "position"=>[516.255735732449, 387.9793814432966], "actions"=>[1, 2]}]}, "Page"=>{"settings"=>{"number"=>1}, "text"=>{"paragraphs"=>[{"linesOfText"=>[{"text"=>"Lorem Ipsum Lorem Ipsum Lorem Ipsum", "xOffset"=>318, "yOffset"=>139, "fontType"=>"arial.ttf", "fontColor"=>[255, 0, 0], "fontHighlightColor"=>[255, 0, 0], "fontSize"=>25}], "highlightingTimes"=>[0], "voiceAudioFile"=>nil}, {"linesOfText"=>[{"text"=>"Noot Noot Noot Noot Noot Noot Pingu Pingu", "xOffset"=>309, "yOffset"=>145, "fontType"=>"ComicSansMS.ttf", "fontColor"=>[255, 0, 0], "fontHighlightColor"=>[255, 0, 0], "fontSize"=>25}], "highlightingTimes"=>[0], "voiceAudioFile"=>nil}]}}}, {"API"=>{"CCMoveTo"=>[{"actionTag"=>5, "duration"=>0, "position"=>[503, 378]}], "CCScaleTo"=>[{"actionTag"=>4, "duration"=>0, "intensity"=>1}], "CCSequence"=>[], "CCDelayTime"=>[], "CCSpawn"=>[], "CCStorySwipeEnded"=>{"runAction"=>[]}, "CCStoryTouchableNode"=>{"nodes"=>[]}, "CCSprites"=>[{"image"=>"random.jpg", "spriteTag"=>3, "position"=>[502.9365035959409, 378.2268041237107], "actions"=>[4, 5]}]}, "Page"=>{"settings"=>{"number"=>2}, "text"=>{"paragraphs"=>[{"linesOfText"=>[{"text"=>"Lorem Ipsum Lorem Ipsum Lorem Ipsum", "xOffset"=>307, "yOffset"=>216, "fontType"=>"arial.ttf", "fontColor"=>[255, 0, 0], "fontHighlightColor"=>[255, 0, 0], "fontSize"=>25}], "highlightingTimes"=>[0], "voiceAudioFile"=>nil}, {"linesOfText"=>[{"text"=>"", "fontType"=>"Arial.ttf", "fontColor"=>[255, 183, 213], "fontHighlightColor"=>[255, 0, 0], "fontSize"=>25}], "highlightingTimes"=>[0], "voiceAudioFile"=>nil}]}}}], "MainMenu"=>{"CCSprites"=>[{"image"=>"random.jpg", "spriteTag"=>1, "position"=>[502.37069649155956, 386.34020618556167], "visible"=>true}], "fallingPhysicsSettings"=>{"plistfilename"=>"snowflake-main-menu.plist"}, "MenuItems"=>[{"normalStateImage"=>"read_it_myself.png", "tappedStateImage"=>"read_it_myself.png", "storyMode"=>"readItMyself", "position"=>[814, 128]}, {"normalStateImage"=>"read_to_me.png", "tappedStateImage"=>"read_to_me.png", "storyMode"=>"readToMe", "position"=>[477, 126]}, {"normalStateImage"=>"auto_play.png", "tappedStateImage"=>"auto_play.png", "storyMode"=>"autoPlay", "position"=>[158, 120]}], "API"=>{}}}
+    }
+  let(:storybook_application) { AbstractStorybookApplication.new(storybook, storybook_json, 'testing') }
+
+  context '#download_files_and_sanitize_json' do
+    it 'downloads remote files ' do
+      storybook_application.stub(:fetch_file) { 'random.jpg' }
+        expect(storybook_application.download_files_and_sanitize_json(ActiveSupport::JSON.decode(storybook_json))).to eq(processed_json_hash)
+    end
+  end
+
+  context '#move_unused_files_out_of_compilation' do
+    it 'moves system files out of compilation' do
+      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf'])
+      removal_paths = [
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'arial.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'ComicSansMS.ttf')
+      ]
+
+      FileUtils.should_receive(:mv).with(removal_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..')).and_return(true)
+      storybook_application.instance_variable_set(:@json_hash, processed_json_hash)
+      storybook_application.move_unused_files_out_of_compilation
+    end
+  end
+
+  context "#move_unused_files_to_resources" do
+    it 'moves system files to resources' do
+      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf'])
+      removal_paths = [
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'arial.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'ComicSansMS.ttf')
+      ]
+      resources_paths = [
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'arial.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'ComicSansMS.ttf')
+      ]
+      FileUtils.should_receive(:mv).with(removal_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..')).and_return(true)
+      FileUtils.should_receive(:mv).with(resources_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR)).and_return(true)
+      storybook_application.instance_variable_set(:@json_hash, processed_json_hash)
+      storybook_application.move_unused_files_out_of_compilation
+      storybook_application.move_unused_files_to_resources
+    end
+  end
+
+  context '#cleanup' do
+    it 'should remove transient files' do
+      storybook_application.instance_variable_set(:@transient_files, ['foo', 'bar'])
+      File.should_receive(:delete).with(*['foo', 'bar'])
+      storybook_application.cleanup
+    end
+  end
+
+  ['compile', 'upload_compiled_application', 'send_notification'].each do |meth|
+    context "##{meth}" do
+      it 'should raise error' do
+        expect do
+          storybook_application.send(meth.to_sym)
+        end.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes sure we do not package unnecessary files with compiled
applications.
