### PR TITLE
ISSUE #517 Used fonts are moved from Resources instead of unused ones.

### DIFF
--- a/app/models/abstract_storybook_application.rb
+++ b/app/models/abstract_storybook_application.rb
@@ -15,7 +15,7 @@ class AbstractStorybookApplication
     @storybook         = storybook
     @json              = storybook_json
     @transient_files   = []
-    @unused_file_names = []
+    @used_file_names = []
     @target            = target
   end
 
@@ -90,7 +90,7 @@ class AbstractStorybookApplication
 
   def stage_for_move(file_name)
     if self.class.system_font_names.include?(file_name)
-      @unused_file_names << file_name if @unused_file_names.exclude?(file_name)
+      @used_file_names << file_name if @used_file_names.exclude?(file_name)
     end
   end
 
@@ -149,6 +149,6 @@ class AbstractStorybookApplication
   end
 
   def unused_files_movement_paths(modifier = '')
-    @unused_file_names.map { |ufn| File.join(CRUCIBLE_RESOURCES_DIR, modifier, ufn) }
+    (self.class.system_font_names - @used_file_names).map { |ufn| File.join(CRUCIBLE_RESOURCES_DIR, modifier, ufn) }
   end
 end

--- a/spec/models/abstract_storybook_application_spec.rb
+++ b/spec/models/abstract_storybook_application_spec.rb
@@ -20,10 +20,10 @@ describe AbstractStorybookApplication do
 
   context '#move_unused_files_out_of_compilation' do
     it 'moves system files out of compilation' do
-      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf'])
+      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf', 'Verdana.ttf', 'CourierNew.ttf'])
       removal_paths = [
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'arial.ttf'),
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'ComicSansMS.ttf')
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'Verdana.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'CourierNew.ttf')
       ]
 
       FileUtils.should_receive(:mv).with(removal_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..')).and_return(true)
@@ -34,14 +34,14 @@ describe AbstractStorybookApplication do
 
   context "#move_unused_files_to_resources" do
     it 'moves system files to resources' do
-      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf'])
+      AbstractStorybookApplication.stub(:system_font_names).and_return(['arial.ttf', 'ComicSansMS.ttf', 'Verdana.ttf', 'CourierNew.ttf'])
       removal_paths = [
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'arial.ttf'),
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'ComicSansMS.ttf')
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'Verdana.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, 'CourierNew.ttf')
       ]
       resources_paths = [
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'arial.ttf'),
-        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'ComicSansMS.ttf')
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'Verdana.ttf'),
+        File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..', 'CourierNew.ttf')
       ]
       FileUtils.should_receive(:mv).with(removal_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR, '..')).and_return(true)
       FileUtils.should_receive(:mv).with(resources_paths, File.join(AbstractStorybookApplication::CRUCIBLE_RESOURCES_DIR)).and_return(true)


### PR DESCRIPTION
This makes sure that the fonts that are not used in json are moved from
compilation process.
