### PR TITLE
(#626) Adds documentation to install 'libsox-fmt-mp3` to support mp3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Setup the application
 
 1. Clone the repository on your machine
-1. Install [sox](http://sox.sourceforge.net/) version 14.4.0
+1. Install [sox](http://sox.sourceforge.net/) version 14.4.0. On ubuntu, you will have to install `libsox-fmt-mp3` to support mp3 files with sox.
 
 	If you don't want to install `sox`, or you cannot get `libmad` &amp; `sox` to play together): comment out `process :convert_audio => args` in `lib/interapptive/carrier_wave/sphinx_audio_converter.rb`
 1. Create a suitable `config/database.yml` (production will likely run on MySQL)

--- a/lib/interapptive/carrier_wave/sound_duration.rb
+++ b/lib/interapptive/carrier_wave/sound_duration.rb
@@ -9,7 +9,8 @@ module Interapptive
         end
       end
 
-      # Expects Sox version 14.4.0
+      # Expects Sox version 14.4.0. On Ubuntu, you'd need libsox-fmt-mp3 to support
+      # mp3 files.
       def store_duration(*args)
         IO.popen("sox #{current_path} -n stat 2>&1") do |output|
           length = output.readlines.detect{|line| line.start_with?('Length')}


### PR DESCRIPTION
files on Ubuntu servers.
