### PR TITLE
Hotfix: add missing code for animation duration #990

### DIFF
--- a/app/assets/javascripts/app/storybook_json.js.coffee
+++ b/app/assets/javascripts/app/storybook_json.js.coffee
@@ -175,7 +175,7 @@ class App.JSON
           delayId = @actionIdCounter.next()
           page.API.CCDelayTime.push
             actionTag: delayId
-            duration: 3
+            duration: keyframe.get('animation_duration')
 
           spawnId = @actionIdCounter.next()
           animationNode =


### PR DESCRIPTION
that was on master, but not on production
