### PR TITLE
Entering `-` in the middle of a coordinate is not allowed #1017

### DIFF
--- a/app/assets/javascripts/app/lib/char_codes.js.coffee
+++ b/app/assets/javascripts/app/lib/char_codes.js.coffee
@@ -1,0 +1,5 @@
+App.Lib.CharCodes =
+  enter:      13
+  minus:      45
+  0:          48
+  9:          57

--- a/app/assets/javascripts/app/lib/key_codes.js.coffee
+++ b/app/assets/javascripts/app/lib/key_codes.js.coffee
@@ -1,4 +1,4 @@
-App.Lib.Keycodes =
+App.Lib.KeyCodes =
   backspace:   8
   tab:         9
   enter:      13
@@ -9,6 +9,4 @@ App.Lib.Keycodes =
   up:         38
   right:      39
   down:       40
-  minus:      45
-  0:          48
-  9:          57
+  minus:     [189, 109, 173]

--- a/app/assets/javascripts/app/views/context_menus/context_menu.js.coffee
+++ b/app/assets/javascripts/app/views/context_menus/context_menu.js.coffee
@@ -35,5 +35,3 @@ class App.Views.ContextMenu extends Backbone.View
 
   _removeCoordinates: ->
     @coordinates.remove()
-
-


### PR DESCRIPTION
to test:
- that trying to add a minus in the middle of a 
  x/y value does not work (the minus is removed)
- that negative x/y are still allowed
- that all coordinate operations still work (move
  by arrows, move by changing the value and pressing
  enter)
