### PR TITLE
Invalidate previews when rendered widgets change #1080

### DIFF
--- a/app/assets/javascripts/app/models/image.js.coffee
+++ b/app/assets/javascripts/app/models/image.js.coffee
@@ -47,5 +47,22 @@ class App.Models.Preview extends App.Models.Image
     @deferredSave() # ignores arguments
 
 
+  widgetChanged: (widget) ->
+    if widget instanceof App.Models.HotspotWidget or
+       widget instanceof App.Models.SpriteOrientation or
+       widget instanceof App.Models.ImageWidget
+      @trigger 'invalid'
+      @invalid = true
+
+
+  isInvalid: ->
+    @invalid
+
+
+  setDataUrl: (dataUrl) ->
+    @invalid = false
+    @set 'data_url', dataUrl
+
+
 _.extend App.Models.Preview::, App.Mixins.DeferredSave
 _.extend App.Models.Preview::, App.Mixins.QueuedSync

--- a/app/assets/javascripts/app/models/keyframe.js.coffee
+++ b/app/assets/javascripts/app/models/keyframe.js.coffee
@@ -74,6 +74,8 @@ class App.Models.Keyframe extends Backbone.Model
     @scene.storybook.videos.on 'remove', @videoRemoved, @
     @scene.storybook.fonts.on  'remove', @fontRemoved, @
 
+    @listenTo @widgets,        'add remove change:position change:scale change:radius',  @widgetsChangedPreview
+    @listenTo @scene.widgets,  '           change:position change:scale change:z_order change:disabled change:image_id', @widgetsChangedPreview
 
   uninitializeWidgets: ->
     @widgets.off 'reset add remove change', @widgetsChanged, @
@@ -84,6 +86,10 @@ class App.Models.Keyframe extends Backbone.Model
 
   widgetsChanged: ->
     @deferredSave()
+
+
+  widgetsChangedPreview: (widget) ->
+    @preview.widgetChanged(widget)
 
 
   # preferred this manual validation out of fear of not being able to save

--- a/app/assets/javascripts/app/views/keyframes/keyframe.js.coffee
+++ b/app/assets/javascripts/app/views/keyframes/keyframe.js.coffee
@@ -16,8 +16,7 @@ class App.Views.Keyframe extends Backbone.View
     @listenTo App.currentSelection, 'change:keyframe', @_activeKeyframeChanged
     @listenTo @model, 'change:animation_duration',  @animationDurationChanged
     @listenTo @model, 'invalid:animation_duration', @invalidAnimationDurationEntered
-    @listenTo @model.widgets,        'add remove change:position change:scale change:radius',  @widgetsChanged
-    @listenTo @model.scene.widgets,  '           change:position change:scale change:z_order change:disabled change:image_id', @widgetsChanged
+    @listenTo @model.preview, 'invalid', @renderPreview
 
 
   remove: ->
@@ -29,7 +28,7 @@ class App.Views.Keyframe extends Backbone.View
     @$el.html(@template(keyframe: @model)).attr('data-id', @model.id)
     if @model.isAnimation()
       @$el.attr('data-is_animation', '1').addClass('animation')
-    if @model.preview.isNew()
+    if @model.preview.isNew() || @model.preview.isInvalid()
       @renderPreview()
 
     @
@@ -62,11 +61,6 @@ class App.Views.Keyframe extends Backbone.View
       animation_duration: Number($(event.currentTarget).val())
 
 
-  widgetsChanged: (model) ->
-    if model instanceof App.Models.HotspotWidget or
-       model instanceof App.Models.SpriteOrientation or
-       model instanceof App.Models.ImageWidget
-      @renderPreview()
 
 
   _configurationClicked: ->
@@ -151,7 +145,7 @@ class App.Views.Keyframe extends Backbone.View
 
   _exportPreview: ->
     image = Canvas2Image.saveAsPNG @previewCanvas, true
-    @model.setPreviewDataUrl image.src
+    @model.preview.setDataUrl image.src
 
 
   _allWidgets: ->

--- a/app/assets/javascripts/app/views/scenes/scene.js.coffee
+++ b/app/assets/javascripts/app/views/scenes/scene.js.coffee
@@ -5,14 +5,8 @@ class App.Views.Scene extends Backbone.View
 
 
   initialize: ->
-    @model.on  'change:preview_data_url', @updatePreview, @
-    @model.on  'destroy', @remove, @
-
-
-  remove: ->
-    @model.off 'change:preview_data_url', @updatePreview, @
-    @model.off 'destroy', @remove, @
-    super
+    @listenTo @model, 'change:preview_data_url', @updatePreview
+    @listenTo @model, 'destroy', @remove
 
 
   render: ->


### PR DESCRIPTION
so when an image, video or sound is deleted, the
previews of the affected keyframes are invalidated
and will be rendered and saved when those keyframes
are shown
