### PR TITLE
Fix initialization order #1118

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,7 +25,8 @@
 
     #main= yield
 
-    :coffee
-      $ ->
+    :javascript
+      $(document).ready(function() {
         App.init()
-        #{ yield :initialization_coffee }
+        #{ yield :initialization_javascript }
+      })

--- a/app/views/storybooks/show.html.haml
+++ b/app/views/storybooks/show.html.haml
@@ -1,7 +1,7 @@
-- content_for :initialization_coffee do
-  App.showStorybook(#{@storybook.id})
-  App.setCurrentUser("#{current_user.id}")
-  App.setSignedInAsUser("#{signed_in_as_user.id}")
+- content_for :initialization_javascript do
+  App.showStorybook(#{@storybook.id});
+  App.setCurrentUser("#{current_user.id}");
+  App.setSignedInAsUser("#{signed_in_as_user.id}");
 
 - content_for :header do
   = render 'layouts/toolbar'


### PR DESCRIPTION
content_for doesn't play well with coffeescript's
indentation, reverting to javascript
