### PR TITLE
Retry loading sprite if img loading fails #1194

### DIFF
--- a/app/assets/javascripts/builder/widgets/lib/sprite.js.coffee
+++ b/app/assets/javascripts/builder/widgets/lib/sprite.js.coffee
@@ -11,3 +11,4 @@ class App.Builder.Widgets.Lib.Sprite extends cc.Sprite
 
     throw new Error("Can not create a App.Builder.Widgets.Lib.Sprite without a url")      unless @url?
     throw new Error("Can not create a App.Builder.Widgets.Lib.Sprite without a filename") unless @filename?
+


### PR DESCRIPTION
to prevent canvas whiteout

@whitman
not sure if in real life this error is temporary
(like S3 failing to deliver an image, once) or
persistent

should we notify the user that something
is not shown?
