### PR TITLE
Fix changing animation duration bug #1339

### DIFF
--- a/app/assets/javascripts/app/models/keyframe.js.coffee
+++ b/app/assets/javascripts/app/models/keyframe.js.coffee
@@ -99,7 +99,8 @@ class App.Models.Keyframe extends Backbone.Model
   animationDurationChanged: ->
     duration = @get('animation_duration')
     if @constructor.isValidAnimationDuration(duration)
-      @save { animation_duration: duration }, patch: true
+      @set animation_duration: duration
+      @deferredSave()
     else
       @trigger 'invalid:animation_duration', duration
       @set
@@ -112,7 +113,8 @@ class App.Models.Keyframe extends Backbone.Model
   autoplayDurationChanged: ->
     duration = @get('autoplay_duration')
     if @constructor.isValidAutoplayDuration(duration)
-      @save { autoplay_duration: duration }, patch: true
+      @set autoplay_duration: duration
+      @deferredSave()
     else
       @trigger 'invalid:autoplay_duration', duration
       @set


### PR DESCRIPTION
What was happening, on very fast updates, was that:
- a save was triggered - S1
- before the response from S1 returned, the value
  would be changed, triggering another save, S2
- the model would be updated with the value from S1,
  triggering S3
  … cycling forever

Replaced the direct save with a call to deferred save
